### PR TITLE
Reflect renaming of alphaNum in docs

### DIFF
--- a/Text/Megaparsec.hs
+++ b/Text/Megaparsec.hs
@@ -180,7 +180,7 @@ import Text.Megaparsec.Prim
 -- @many p@ applies the parser @p@ /zero/ or more times. Returns a list of
 -- the returned values of @p@.
 --
--- > identifier = (:) <$> letter <*> many (alphaNum <|> char '_')
+-- > identifier = (:) <$> letter <*> many (alphaNumChar <|> char '_')
 
 -- $some
 --


### PR DESCRIPTION
The `alphaNum` parser was renamed to `alphaNumChar`, yet the docs
weren't full updated to reflect this change.